### PR TITLE
updated to python 3.11 and faust-streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # faust-protobuf
 
-An example how use [`faust`](https://github.com/robinhood/faust) a python basesd stream processing library with `protobuf`
+An example how use [`faust-streaming`](https://github.com/faust-streaming/faust) a python based stream processing library with `protobuf`
 
 ## Run Instructions
-1. Run `make install`
-1. Activate conda environmet
-1. Run `make proto`
-1. Run `make run`
 
+1. Run `make install`
+2. Activate conda environment
+3. Run `make proto`
+4. Run `make run`

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,13 +1,13 @@
 channels:
-- defaults
-- conda-forge
+  - defaults
+  - conda-forge
 dependencies:
-- python=3.8
-- make
-- jq
-- pip
-- pip:
-  - faust[debug]
-  - protobuf
-  - grpcio
-  - grpcio-tools
+  - python=3.11
+  - make
+  - jq
+  - pip
+  - pip:
+      - faust-streaming
+      - protobuf
+      - grpcio
+      - grpcio-tools


### PR DESCRIPTION
Example wasn't working for Python 3.10+ and Faust is not maintained anymore. This small change should make it work with Python 3.11 and Faust Streaming as a drop-in replacement of the original one.
